### PR TITLE
fix: dependabot groups react

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,18 @@ updates:
     # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: "daily"
+    groups:
+      react-ecosystem:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "react-router"
+          - "react-router-dom"
+          - "@types/react"
+          - "@types/react-dom"
+          - "@testing-library/react"
+        exclude-patterns:
+          - "react-scripts"
 
   # Enable version updates for Docker
   - package-ecosystem: "docker"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated dependency management to group React ecosystem updates (React, React DOM, React Router, related types, and testing libraries) into single PRs, excluding react-scripts. This reduces PR noise and simplifies reviews. Security updates remain unaffected. No changes to app behavior or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->